### PR TITLE
[Fix](example)(mdigits) Don't ref assets in pubspec

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -61,8 +61,7 @@ flutter:
   uses-material-design: true
 
   # To add assets to your application, add an assets section, like this:
-  assets:
-    - assets/stim.txt
+  # assets:
     # - images/a_dot_burr.jpeg
   #   - images/a_dot_ham.jpeg
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,4 @@ flutter:
 
   uses-material-design: true
 
-  assets:
-    - assets/images/listen.jpeg
-    # - assets/stim.txt
+  # assets:


### PR DESCRIPTION
## Description

Fix bug because the assets folder were specified in pubspec but no specific asset is specified because none are used.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [x] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
