### PR TITLE
Implement self-paced begin screen

### DIFF
--- a/lib/activity/begin_view.dart
+++ b/lib/activity/begin_view.dart
@@ -21,7 +21,7 @@ class BeginView extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
               const DefaultText(
-                'Comencemos',
+                'Comenzar',
               ),
               const BetweenWidgetsSpace(),
               ElevatedButton(

--- a/lib/activity/begin_view.dart
+++ b/lib/activity/begin_view.dart
@@ -3,10 +3,13 @@ import 'package:mdigits/common/centeredbox.dart';
 import 'package:mdigits/common/default_appbar.dart';
 import 'package:mdigits/common/default_text.dart';
 import 'package:mdigits/common/spacing_holder.dart';
+import 'package:mdigits/mdigits.dart';
 
 /// Screen that allows participants to indicate when to start task.
 class BeginView extends StatelessWidget {
-  const BeginView({Key? key}) : super(key: key);
+  final Function beginFunction;
+
+  const BeginView({Key? key, required this.beginFunction}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -26,7 +29,7 @@ class BeginView extends StatelessWidget {
               const BetweenWidgetsSpace(),
               ElevatedButton(
                 onPressed: () {
-                  // Get.put(MDigits());
+                  beginFunction();
                 },
                 child: const DefaultText('Seguir'),
               ),

--- a/lib/mdigits.dart
+++ b/lib/mdigits.dart
@@ -36,7 +36,7 @@ class MDigits extends GetxController {
 
   @override
   onReady() {
-    run();
+    Get.to(() => BeginView(beginFunction: run));
   }
 
   /// Add trial data to the db


### PR DESCRIPTION
## Description

Allows the user to indicate when to start the activity. Important because now the experimenter may start the activity by going to the begin screen and then the participant may choose when to start.

Avoid begin the activity without the participant being ready.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
