### PR TITLE
[improvment] Return to screen that called mdigits after mdigits finishes

### DIFF
--- a/lib/mdigits.dart
+++ b/lib/mdigits.dart
@@ -101,20 +101,20 @@ class MDigits extends GetxController {
   void run() {
     switch (_status) {
       case Step.stim:
-        Get.to(() => TrialStimView());
+        Get.off(() => TrialStimView());
         _updateStep();
         break;
       case Step.response:
-        Get.to(TrialResponseView());
+        Get.off(TrialResponseView());
         _updateStep();
         break;
       case Step.rest:
-        Get.to(RestView());
+        Get.off(RestView());
         _updateStep();
         break;
       case Step.completed:
         // _saveData();
-        Get.to(const EndView());
+        Get.off(const EndView());
         return;
       default:
         run();

--- a/lib/mdigits.dart
+++ b/lib/mdigits.dart
@@ -115,6 +115,7 @@ class MDigits extends GetxController {
       case Step.completed:
         // _saveData();
         Get.off(const EndView());
+        Get.back();
         return;
       default:
         run();


### PR DESCRIPTION
## Description

mdigits returns to the screen that started the mdigits activity without knowledge of the caller.

Requires Getx

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
