### PR TITLE
Return to mdigits caller from mdigits controller

### DIFF
--- a/lib/src/end/end_controller.dart
+++ b/lib/src/end/end_controller.dart
@@ -1,12 +1,14 @@
 import 'package:get/get.dart';
+import 'package:mdigits/src/mdigits/mdigits_controller.dart';
 
 class EndController extends GetxController {
   final Duration waitTime = const Duration(seconds: 2);
 
   Future<void> toNextScreen() async {
+    MDigitsController mDigitsController = Get.find();
     await Future.delayed(
       waitTime,
-      () => Get.back(),
+      () => mDigitsController.endSession(),
     );
   }
 }

--- a/lib/src/mdigits/mdigits_controller.dart
+++ b/lib/src/mdigits/mdigits_controller.dart
@@ -137,4 +137,8 @@ class MDigitsController extends GetxController {
   //       run();
   //   }
   // }
+
+  void endSession() {
+    Get.back();
+  }
 }


### PR DESCRIPTION
## Description

Avoid coupling between components by returning from the MDigitsController which is responsible for controlling the MDigits "widget flow".

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
