### PR TITLE
[improv] Allow running mdigits repeatedly and returning its data

### DIFF
--- a/lib/src/mdigits/mdigits_controller.dart
+++ b/lib/src/mdigits/mdigits_controller.dart
@@ -98,6 +98,7 @@ class MDigitsController extends GetxController {
 
   /// Reset mDigits so it can be used again repeatedly
   Future<void> reset() async {
+    data.clear();
     await setup();
     taskStep(TaskStep.instructions);
   }

--- a/lib/src/mdigits/mdigits_controller.dart
+++ b/lib/src/mdigits/mdigits_controller.dart
@@ -91,4 +91,10 @@ class MDigitsController extends GetxController {
   void endSession() {
     Get.back();
   }
+
+  /// Reset mDigits so it can be used again repeatedly
+  Future<void> reset() async {
+    await setup();
+    taskStep(TaskStep.instructions);
+  }
 }

--- a/lib/src/mdigits/mdigits_controller.dart
+++ b/lib/src/mdigits/mdigits_controller.dart
@@ -91,8 +91,9 @@ class MDigitsController extends GetxController {
   }
 
   Future<void> endSession() async {
+    List<TrialData> datatoReturn = List<TrialData>.from(data);
     await reset();
-    Get.back();
+    Get.back(result: datatoReturn);
   }
 
   /// Reset mDigits so it can be used again repeatedly

--- a/lib/src/mdigits/mdigits_controller.dart
+++ b/lib/src/mdigits/mdigits_controller.dart
@@ -88,7 +88,8 @@ class MDigitsController extends GetxController {
     await _stimuli.prepareStimPool();
   }
 
-  void endSession() {
+  Future<void> endSession() async {
+    await reset();
     Get.back();
   }
 

--- a/lib/src/mdigits/mdigits_controller.dart
+++ b/lib/src/mdigits/mdigits_controller.dart
@@ -77,7 +77,9 @@ class MDigitsController extends GetxController {
   }
 
   bool _responseStatusFollows() => taskStep.value == TaskStep.stim;
-  bool _stimStatusFollows() => taskStep.value == TaskStep.rest;
+  bool _stimStatusFollows() =>
+      (taskStep.value == TaskStep.rest) ||
+      (taskStep.value == TaskStep.instructions);
   bool restStatusFollows() =>
       _stimuli.stim.stimCountUsed != 0 && _stimuli.stim.stimCountUsed % 2 == 0;
   bool _completedStatusFollows() => _stimuli.stim.stimCountRemaining == 0;

--- a/lib/src/mdigits/mdigits_controller.dart
+++ b/lib/src/mdigits/mdigits_controller.dart
@@ -8,7 +8,7 @@ import 'package:mdigits/src/randomize.dart';
 /// The task sequence which includes stim, response, rest, end
 class MDigitsController extends GetxController {
   /// Provides access and manages the stimuli
-  late final StimController _stimuli;
+  late StimController _stimuli;
 
   /// Data for all trials
   /// Used to provide data to app

--- a/stimuli/lib/stim.dart
+++ b/stimuli/lib/stim.dart
@@ -2,7 +2,7 @@ class Stimuli {
   /// Stimuli manager. Can be created from a file or iterable.
 
   /// A list of the stimuli
-  late List<String> stimuli = <String>[];
+  late List<String> _stimuli = <String>[];
 
   /// Current stimuli after running the [next] method.
   late String currentStim;
@@ -11,23 +11,24 @@ class Stimuli {
   late int stimCountOriginal;
 
   /// Default constructor requires a list of stimuli.
-  Stimuli({required this.stimuli}) {
-    stimCountOriginal = stimuli.length;
+  Stimuli({required stimuli}) {
+    _stimuli = List<String>.from(stimuli);
+    stimCountOriginal = _stimuli.length;
   }
 
   /// Number of stim that remain to be used
-  int get stimCountRemaining => stimuli.length;
+  int get stimCountRemaining => _stimuli.length;
 
   /// Number of stim that have been used
   int get stimCountUsed => stimCountOriginal - stimCountRemaining;
 
   /// Get the next stim from stimuli.
   void next() {
-    currentStim = stimuli.removeAt(0);
+    currentStim = _stimuli.removeAt(0);
   }
 
   /// Randomize the order of the stimuli.
   void randomize() {
-    stimuli.shuffle();
+    _stimuli.shuffle();
   }
 }

--- a/stimuli/test/stimuli_test.dart
+++ b/stimuli/test/stimuli_test.dart
@@ -14,7 +14,7 @@ void main() async {
 stimFromFileTest() async {
   testWidgets('Assets folder', (tester) async {
     final s = await createStimFromFile('assets/stimuli_tests.txt');
-    expect(s.stimuli, ['del', 'dos']);
+    expect(s._stimuli, ['del', 'dos']);
   });
 }
 
@@ -70,11 +70,11 @@ randomizeTest() async {
     stimuli5.randomize();
 
     final firstStimulusEachStimuli = <String>[
-      stimuli1.stimuli.first,
-      stimuli2.stimuli.first,
-      stimuli3.stimuli.first,
-      stimuli4.stimuli.first,
-      stimuli5.stimuli.first,
+      stimuli1._stimuli.first,
+      stimuli2._stimuli.first,
+      stimuli3._stimuli.first,
+      stimuli4._stimuli.first,
+      stimuli5._stimuli.first,
     ];
 
     bool obs = firstStimulusEachStimuli.every(((element) => element == 'a'));


### PR DESCRIPTION
## Description

The changes made allow running mdigits repeatedly and extracting the data. It requires resetting mdigits after each run including the data, stim, step.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
