### PR TITLE
Disposer of GetXControllers after use

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -45,9 +45,9 @@ class _MyHomePageState extends State<MyHomePage> {
                   participantID: '000',
                   processData: print,
                 );
-                List data = await Get.to(MDigitsView(
-                  config: config,
-                ));
+                List data = await Get.to(() => MDigitsView(
+                      config: config,
+                    ));
                 print('main $data');
               },
               child: Text(

--- a/lib/src/mdigits/mdigits_controller.dart
+++ b/lib/src/mdigits/mdigits_controller.dart
@@ -64,8 +64,7 @@ class MDigitsController extends GetxController {
 
   /// Setup everything needed to start the task sequence
   Future<void> setup() async {
-    _stimuli =
-        Get.put(StimController(stimList: config.stimList), permanent: true);
+    _stimuli = Get.put(StimController(stimList: config.stimList));
     await _stimuli.prepareStimPool();
   }
 
@@ -74,14 +73,14 @@ class MDigitsController extends GetxController {
     if (config.processData != null) {
       config.processData!(datatoReturn);
     }
-    await reset();
+    // await reset();
     Get.back(result: datatoReturn);
   }
 
   /// Reset mDigits so it can be used again repeatedly
   Future<void> reset() async {
-    data.clear();
-    await setup();
+    // data.clear();
+    // await setup();
     taskStep(TaskStep.instructions);
   }
 }

--- a/lib/src/mdigits/mdigits_view.dart
+++ b/lib/src/mdigits/mdigits_view.dart
@@ -15,7 +15,7 @@ class MDigitsView extends StatelessWidget {
   late final MDigitsController mDigits;
 
   MDigitsView({super.key, required this.config}) {
-    mDigits = Get.put(MDigitsController(config), permanent: true);
+    mDigits = Get.put(MDigitsController(config));
   }
 
   @override


### PR DESCRIPTION
## Description
Disposing of the controller after use makes new MDigits runs fresh because data from different runs are independent of each other.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
