### PR TITLE
improv: Handle stim step explicitly

### DIFF
--- a/lib/src/mdigits/mdigits_controller.dart
+++ b/lib/src/mdigits/mdigits_controller.dart
@@ -32,15 +32,14 @@ class MDigitsController extends GetxController {
       taskStep(TaskStep.stim);
     } else if (restStatusFollows()) {
       taskStep(TaskStep.rest);
-    } else {
-      taskStep(TaskStep.stim);
     }
   }
 
   bool _responseStatusFollows() => taskStep.value == TaskStep.stim;
   bool _stimStatusFollows() =>
       (taskStep.value == TaskStep.rest) ||
-      (taskStep.value == TaskStep.instructions);
+      (taskStep.value == TaskStep.instructions) ||
+      (taskStep.value == TaskStep.response);
   bool restStatusFollows() =>
       _stimuli.stim.stimCountUsed != 0 && _stimuli.stim.stimCountUsed % 2 == 0;
   bool _completedStatusFollows() => _stimuli.stim.stimCountRemaining == 0;


### PR DESCRIPTION
## Description

This change improves readability because there has to be a check for going to the stim step before checking for rest step. This way the check for the stim step is done in the same place.



## Related Issue

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
