### PR TITLE
Fix rest_view horizontal padding

### DIFF
--- a/lib/src/components/response/response_view.dart
+++ b/lib/src/components/response/response_view.dart
@@ -20,7 +20,7 @@ class ResponseView extends StatelessWidget {
       },
       child: Screen(
         children: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 300),
+          padding: const EdgeInsets.symmetric(horizontal: 100),
           child: Column(
             children: <Widget>[
               const DefaultText(


### PR DESCRIPTION
## Description

The horizontal padding was too high and caused the ResponseView to become distorted in portrait view

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
