### PR TITLE
improv: Don't use participant_id

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -60,7 +60,6 @@ class _MyHomePageState extends State<MyHomePage> {
     UserConfig config = UserConfig(
       stimListPractice: ['01', '234'],
       stimListExperimental: ['5678', '01567', '987654'],
-      participantID: '000',
     );
     DigitSpanTasksData data = await Get.to(() => DigitSpanForward(
           config: config,
@@ -73,7 +72,6 @@ class _MyHomePageState extends State<MyHomePage> {
     UserConfig config = UserConfig(
       stimListPractice: ['23', '567'],
       stimListExperimental: ['0123', '45678', '901234'],
-      participantID: '000',
     );
     DigitSpanTasksData data = await Get.to(() => DigitSpanBackwards(
           config: config,

--- a/lib/src/digit_span_task/components/config/user_config.dart
+++ b/lib/src/digit_span_task/components/config/user_config.dart
@@ -14,13 +14,10 @@ class UserConfig extends GetxController {
   /// are randomized (e.g., "123" may be turned into "213").
   late final List<String> stimListExperimental;
 
-  /// Unique id to identify the participant's data
-  final String participantID;
-
-  UserConfig(
-      {required stimListPractice,
-      required stimListExperimental,
-      required this.participantID}) {
+  UserConfig({
+    required stimListPractice,
+    required stimListExperimental,
+  }) {
     this.stimListPractice = randomizeDigitsInSets(stimListPractice);
     this.stimListExperimental = randomizeDigitsInSets(stimListExperimental);
   }

--- a/lib/src/digit_span_task/components/data/data_manager.dart
+++ b/lib/src/digit_span_task/components/data/data_manager.dart
@@ -11,16 +11,14 @@ class DataManager extends GetxController {
   DataModel practiceData = DataModel();
   DataModel experimentalData = DataModel();
 
-  /// Add data [participantID], [stim], [resp] from a single trial to
+  /// Add data [stim], [resp] from a single trial to
   /// the manager. Uses [isPractice] to get the data for the current phase.
   void addTrialData({
-    required String participantID,
     required String stim,
     required String resp,
     required bool isPractice,
   }) {
     TrialData trialData = TrialData(
-      participantID: participantID,
       stim: stim,
       response: resp,
     );

--- a/lib/src/digit_span_task/components/data/trial_data.dart
+++ b/lib/src/digit_span_task/components/data/trial_data.dart
@@ -1,17 +1,15 @@
 /// Model for the data of a single trial
 class TrialData {
-  final String participantID;
   final String stim;
   final String response;
 
   TrialData({
-    required this.participantID,
     required this.stim,
     required this.response,
   });
 
   @override
   String toString() {
-    return "Participant $participantID, stim: $stim, resp: $response";
+    return "stim: $stim, resp: $response";
   }
 }

--- a/lib/src/digit_span_task/components/response/response_controller.dart
+++ b/lib/src/digit_span_task/components/response/response_controller.dart
@@ -24,7 +24,6 @@ class ResponseController extends GetxController {
     String response = textController.text.trim();
 
     _data.addTrialData(
-      participantID: _config.userConfig.participantID,
       stim: _stim.stim.currentStim,
       resp: response,
       isPractice: _config.isPractice,


### PR DESCRIPTION
## Description

This piece of data should be collected and managed by the app. It should not be managed by digit_span_task because digit_span_task collect data for a single session for a single participant and returns that data.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
