### PR TITLE
Require participant and session id i UserConfig

### DIFF
--- a/lib/src/digit_span_task/components/config/user_config.dart
+++ b/lib/src/digit_span_task/components/config/user_config.dart
@@ -20,10 +20,18 @@ class UserConfig extends GetxController {
   /// the [sessionID] is an unique identifier across all the sessions for this
   /// participant.
   final String sessionID;
+
+  /// ID that uniquely identifies this participant.
+  /// It will be used to pair the different data collected by [digit_span_tasks]
+  /// for the participant. So it is essential that the [participantID] is an
+  /// unique identifier across all participant.
+  final String participantID;
+
   UserConfig({
     required stimListPractice,
     required stimListExperimental,
     required this.sessionID,
+    required this.participantID,
   }) {
     this.stimListPractice = randomizeDigitsInSets(stimListPractice);
     this.stimListExperimental = randomizeDigitsInSets(stimListExperimental);

--- a/lib/src/digit_span_task/components/config/user_config.dart
+++ b/lib/src/digit_span_task/components/config/user_config.dart
@@ -14,9 +14,16 @@ class UserConfig extends GetxController {
   /// are randomized (e.g., "123" may be turned into "213").
   late final List<String> stimListExperimental;
 
+  /// ID that uniquely identifies this participant's session.
+  /// It will be used to pair the different data collected by [digit_span_tasks]
+  /// for the participant's particular session. So it is essential that
+  /// the [sessionID] is an unique identifier across all the sessions for this
+  /// participant.
+  final String sessionID;
   UserConfig({
     required stimListPractice,
     required stimListExperimental,
+    required this.sessionID,
   }) {
     this.stimListPractice = randomizeDigitsInSets(stimListPractice);
     this.stimListExperimental = randomizeDigitsInSets(stimListExperimental);


### PR DESCRIPTION
## Description

These pieces of info will be used to pair the different data collected by digit_span_tasks for the participant's session.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
