### PR TITLE
Use sessionID and participantID in DSF DSB

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -23,6 +23,8 @@ class MyApp extends StatelessWidget {
 class MyHomePage extends StatefulWidget {
   const MyHomePage({super.key});
 
+  final String participantID = '101';
+
   @override
   State<MyHomePage> createState() => _MyHomePageState();
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -24,6 +24,7 @@ class MyHomePage extends StatefulWidget {
   const MyHomePage({super.key});
 
   final String participantID = '101';
+  final String sessionID = '001';
 
   @override
   State<MyHomePage> createState() => _MyHomePageState();

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -50,7 +50,9 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             const SizedBox(height: 10),
             ElevatedButton(
-              onPressed: runDigitSpanBackwards,
+              onPressed: () => runDigitSpanBackwards(
+                participantID: widget.participantID,
+              ),
               child: Text(
                 'Digit Span Backwards',
                 style: Theme.of(context).textTheme.titleLarge,
@@ -80,10 +82,11 @@ class _MyHomePageState extends State<MyHomePage> {
     print('\n\n\nFORWARD data \n $data');
   }
 
-  void runDigitSpanBackwards() async {
+  void runDigitSpanBackwards({required String participantID}) async {
     UserConfig config = UserConfig(
       stimListPractice: ['23', '567'],
       stimListExperimental: ['0123', '45678', '901234'],
+      participantID: participantID,
     );
     DigitSpanTasksData data = await Get.to(() => DigitSpanBackwards(
           config: config,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -52,6 +52,7 @@ class _MyHomePageState extends State<MyHomePage> {
             ElevatedButton(
               onPressed: () => runDigitSpanBackwards(
                 participantID: widget.participantID,
+                sessionID: widget.sessionID,
               ),
               child: Text(
                 'Digit Span Backwards',
@@ -82,11 +83,15 @@ class _MyHomePageState extends State<MyHomePage> {
     print('\n\n\nFORWARD data \n $data');
   }
 
-  void runDigitSpanBackwards({required String participantID}) async {
+  void runDigitSpanBackwards({
+    required String participantID,
+    required String sessionID,
+  }) async {
     UserConfig config = UserConfig(
       stimListPractice: ['23', '567'],
       stimListExperimental: ['0123', '45678', '901234'],
       participantID: participantID,
+      sessionID: sessionID,
     );
     DigitSpanTasksData data = await Get.to(() => DigitSpanBackwards(
           config: config,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -39,7 +39,8 @@ class _MyHomePageState extends State<MyHomePage> {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             ElevatedButton(
-              onPressed: runDigitSpanForward,
+              onPressed: () =>
+                  runDigitSpanForward(participantID: widget.participantID),
               child: Text(
                 'Digit Span Forward',
                 style: Theme.of(context).textTheme.titleLarge,
@@ -60,10 +61,11 @@ class _MyHomePageState extends State<MyHomePage> {
     );
   }
 
-  void runDigitSpanForward() async {
+  void runDigitSpanForward({required String participantID}) async {
     UserConfig config = UserConfig(
       stimListPractice: ['01', '234'],
       stimListExperimental: ['5678', '01567', '987654'],
+      participantID: participantID,
     );
     DigitSpanTasksData data = await Get.to(() => DigitSpanForward(
           config: config,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -39,8 +39,10 @@ class _MyHomePageState extends State<MyHomePage> {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             ElevatedButton(
-              onPressed: () =>
-                  runDigitSpanForward(participantID: widget.participantID),
+              onPressed: () => runDigitSpanForward(
+                participantID: widget.participantID,
+                sessionID: widget.sessionID,
+              ),
               child: Text(
                 'Digit Span Forward',
                 style: Theme.of(context).textTheme.titleLarge,
@@ -61,11 +63,15 @@ class _MyHomePageState extends State<MyHomePage> {
     );
   }
 
-  void runDigitSpanForward({required String participantID}) async {
+  void runDigitSpanForward({
+    required String participantID,
+    required String sessionID,
+  }) async {
     UserConfig config = UserConfig(
       stimListPractice: ['01', '234'],
       stimListExperimental: ['5678', '01567', '987654'],
       participantID: participantID,
+      sessionID: sessionID,
     );
     DigitSpanTasksData data = await Get.to(() => DigitSpanForward(
           config: config,


### PR DESCRIPTION
## Description

The sessionID and participantID are now used when  running the cognitive tasks to identify the data collected.

These changes address a gap left by commit c90663af4db357c7515b769ce4d07f2ecafe064a where these fields were required in the digit span config, but not required when running the cognitive tasks.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [x] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
