### PR TITLE
Make startTime and endTime fields in the data manager

### DIFF
--- a/lib/src/digit_span_task/components/activity/activity_controller.dart
+++ b/lib/src/digit_span_task/components/activity/activity_controller.dart
@@ -47,7 +47,7 @@ class ActivityController extends GetxController {
   }
 
   Future<void> endSession() async {
-    _data.addEndTime(_config.isPractice);
+    _data.endTime = DateTime.now();
     await reset();
     Get.back();
   }

--- a/lib/src/digit_span_task/components/activity/activity_view.dart
+++ b/lib/src/digit_span_task/components/activity/activity_view.dart
@@ -20,7 +20,7 @@ class ActivityView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    data.addStartTime(_config.isPractice);
+    data.startTime = DateTime.now();
     return Obx(() {
       switch (mDigits.taskStep.value) {
         case TaskStep.instructions:

--- a/lib/src/digit_span_task/components/data/data_manager.dart
+++ b/lib/src/digit_span_task/components/data/data_manager.dart
@@ -12,6 +12,7 @@ class DataManager extends GetxController {
   final InMemoryDB db = InMemoryDB();
   final DSConfig _config = Get.find();
   late final DateTime _startTime;
+  late final DateTime _endTime;
   DataModel practiceData = DataModel();
   DataModel experimentalData = DataModel();
 

--- a/lib/src/digit_span_task/components/data/data_manager.dart
+++ b/lib/src/digit_span_task/components/data/data_manager.dart
@@ -41,13 +41,6 @@ class DataManager extends GetxController {
     }
   }
 
-  /// Adds the time at which the session ended for the current
-  /// phase (practice or experimental) based on the [isPractice] flag.
-  void addEndTime(bool isPractice) {
-    DataModel data = getData(isPractice);
-    data.sessionData.endTime = DateTime.now();
-  }
-
   /// Exports the data collected during the session.
   /// Returns a custom object named [DigitSpanTasksData] that includes data for the
   /// practice and experimental phase.

--- a/lib/src/digit_span_task/components/data/data_manager.dart
+++ b/lib/src/digit_span_task/components/data/data_manager.dart
@@ -41,6 +41,10 @@ class DataManager extends GetxController {
     }
   }
 
+  /// Sets the end time for the session, but only if this is a experimental
+  /// phase. Practice and experimental phases are considered part of the same
+  /// session so the end time for the experimental phase is considered the
+  /// end of the session.
   set endTime(DateTime time) {
     if (!_config.isPractice) {
       _endTime = DateTime.now();

--- a/lib/src/digit_span_task/components/data/data_manager.dart
+++ b/lib/src/digit_span_task/components/data/data_manager.dart
@@ -30,6 +30,10 @@ class DataManager extends GetxController {
     data.trialData.add(trialData);
   }
 
+  /// Sets the start time for the session, but only if this is a practice phase.
+  /// Practice and experimental phases are considered part of the same session
+  /// so the start time for the practice phase is considered the beginning of
+  /// the session.
   set startTime(DateTime time) {
     if (_config.isPractice) {
       _startTime = time;

--- a/lib/src/digit_span_task/components/data/data_manager.dart
+++ b/lib/src/digit_span_task/components/data/data_manager.dart
@@ -30,6 +30,12 @@ class DataManager extends GetxController {
     data.trialData.add(trialData);
   }
 
+  set startTime(DateTime time) {
+    if (_config.isPractice) {
+      _startTime = time;
+    }
+  }
+
   /// Adds the time at which the session ended for the current
   /// phase (practice or experimental) based on the [isPractice] flag.
   void addEndTime(bool isPractice) {

--- a/lib/src/digit_span_task/components/data/data_manager.dart
+++ b/lib/src/digit_span_task/components/data/data_manager.dart
@@ -11,6 +11,7 @@ import 'package:digit_span_tasks/src/digit_span_task/components/data/data_model.
 class DataManager extends GetxController {
   final InMemoryDB db = InMemoryDB();
   final DSConfig _config = Get.find();
+  late final DateTime _startTime;
   DataModel practiceData = DataModel();
   DataModel experimentalData = DataModel();
 

--- a/lib/src/digit_span_task/components/data/data_manager.dart
+++ b/lib/src/digit_span_task/components/data/data_manager.dart
@@ -41,6 +41,12 @@ class DataManager extends GetxController {
     }
   }
 
+  set endTime(DateTime time) {
+    if (!_config.isPractice) {
+      _endTime = DateTime.now();
+    }
+  }
+
   /// Exports the data collected during the session.
   /// Returns a custom object named [DigitSpanTasksData] that includes data for the
   /// practice and experimental phase.

--- a/lib/src/digit_span_task/components/data/data_manager.dart
+++ b/lib/src/digit_span_task/components/data/data_manager.dart
@@ -30,13 +30,6 @@ class DataManager extends GetxController {
     data.trialData.add(trialData);
   }
 
-  /// Adds the time at which the session started for the current
-  /// phase (practice or experimental) based on the [isPractice] flag.
-  void addStartTime(bool isPractice) {
-    DataModel data = getData(isPractice);
-    data.sessionData.startTime = DateTime.now();
-  }
-
   /// Adds the time at which the session ended for the current
   /// phase (practice or experimental) based on the [isPractice] flag.
   void addEndTime(bool isPractice) {


### PR DESCRIPTION
## Description

These fields are defined by the user using the setter methods provided.

Because practice and experimental phases are considered part of the same session, the startTime is set with the practice phase start time and the endTime is set with the experimental phase end time.

## Related Issue

<!-- If your PR refers to a related issue, link it here using `fix #[number-of-issue]`. -->
<!-- If this is not related to an issue, please delete this section (`Related Issue`). -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [project's code of conduct][code_conduct].
- [ ] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
