### PR TITLE
Define a new data model that uses data from the cognitive_data

### DIFF
--- a/lib/src/digit_span_task/components/data/digit_span_task_data.dart
+++ b/lib/src/digit_span_task/components/data/digit_span_task_data.dart
@@ -15,4 +15,15 @@ class DigitSpanTaskData {
     required this.session,
     required this.device,
   });
+
+  @override
+  String toString() {
+    final representation = 'Session data:'
+        '\n${session.toString()}'
+        '\nDevice data:'
+        '\n${device.toString()}'
+        '\nTrials data:'
+        '\n${trials.toString()}';
+    return representation;
+  }
 }

--- a/lib/src/digit_span_task/components/data/digit_span_task_data.dart
+++ b/lib/src/digit_span_task/components/data/digit_span_task_data.dart
@@ -1,0 +1,18 @@
+import 'package:cognitive_data/cognitive_data.dart';
+
+class DigitSpanTaskData {
+  /// Data of all the trials
+  late final List<Trial> trials;
+
+  /// Metadata about the session
+  late final Session session;
+
+  /// Metadata about the device on which the data was collected
+  late final Device device;
+
+  DigitSpanTaskData({
+    required this.trials,
+    required this.session,
+    required this.device,
+  });
+}

--- a/lib/src/digit_span_task/components/data/digit_span_task_data.dart
+++ b/lib/src/digit_span_task/components/data/digit_span_task_data.dart
@@ -1,7 +1,7 @@
 import 'package:cognitive_data/cognitive_data.dart';
 
 class DigitSpanTaskData {
-  /// Data of all the trials
+  /// Data for all trials
   late final List<Trial> trials;
 
   /// Metadata about the session

--- a/lib/src/digit_span_task/components/data/digit_span_task_data.dart
+++ b/lib/src/digit_span_task/components/data/digit_span_task_data.dart
@@ -1,5 +1,8 @@
 import 'package:cognitive_data/cognitive_data.dart';
 
+/// Structured data collected for a single session.
+/// Includes data about the [trials] (practice and experimental),
+/// and metadata about the [session] and [device] used to collect the data.
 class DigitSpanTaskData {
   /// Data for all trials
   late final List<Trial> trials;

--- a/test/src/digit_span_task/components/data/digit_span_task_data_test.dart
+++ b/test/src/digit_span_task/components/data/digit_span_task_data_test.dart
@@ -1,0 +1,61 @@
+import 'package:cognitive_data/cognitive_data.dart';
+import 'package:digit_span_tasks/src/digit_span_task/components/data/digit_span_task_data.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    "DigitSpanTaskData.toString returns correct representation",
+    () {
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+      /// arrange
+      /// session
+      final Session session = Session(
+          participantID: '101',
+          sessionID: '001',
+          startTime: DateTime.now(),
+          endTime: DateTime.now());
+
+      /// device
+      final Device device = Device(participantID: '101', sessionID: '001');
+
+      /// list trial
+      final List<Trial> trials = <Trial>[
+        Trial(
+            participantID: '101',
+            sessionID: '001',
+            trialType: TrialType.practice,
+            stim: '456',
+            response: '123'),
+        Trial(
+            participantID: '102',
+            sessionID: '002',
+            trialType: TrialType.practice,
+            stim: '789',
+            response: '987'),
+      ];
+
+      /// DigitSpanTaskData
+      DigitSpanTaskData data = DigitSpanTaskData(
+        session: session,
+        device: device,
+        trials: trials,
+      );
+
+      /// expected
+      final expectedRepr = 'Session data:'
+          '\n${session.toString()}'
+          '\nDevice data:'
+          '\n${device.toString()}'
+          '\nTrials data:'
+          '\n${trials.toString()}';
+
+      /// act
+      /// tostring
+      final String actualRepr = data.toString();
+
+      /// assert
+      expect(actualRepr, expectedRepr);
+    },
+  );
+}


### PR DESCRIPTION
## Description

The new data model `DigitSpanTaskData` is used to clean and structure the data managed using the `cognitive_data` package data to users

The new data model `DigitSpanTaskData` is used provide users with a clean and structured version of the data managed using the `cognitive_data` package.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
