### PR TITLE
Update method that exports data to based on the new way that data is managed

### DIFF
--- a/lib/src/digit_span_task/components/data/data_manager.dart
+++ b/lib/src/digit_span_task/components/data/data_manager.dart
@@ -6,6 +6,7 @@ import 'package:cognitive_data/models/trial_type.dart';
 import 'package:digit_span_tasks/digit_span_tasks.dart';
 import 'package:digit_span_tasks/src/digit_span_task/components/config/ds_config.dart';
 import 'package:digit_span_tasks/src/digit_span_task/components/config/session_type.dart';
+import 'package:digit_span_tasks/src/digit_span_task/components/data/digit_span_task_data.dart';
 import 'package:get/get.dart';
 import 'package:digit_span_tasks/src/digit_span_task/components/data/data_model.dart';
 
@@ -64,10 +65,13 @@ class DataManager extends GetxController {
   /// Exports the data collected during the session.
   /// Includes data about the [trials] (practice and experimental)
   /// and metadata about the [session] and [device] used to collect the data.
-  DigitSpanTasksData export() {
-    DigitSpanTasksData data = DigitSpanTasksData(
-      practiceData: practiceData,
-      experimentalData: experimentalData,
+  DigitSpanTaskData export() {
+    collectMetadata();
+
+    final DigitSpanTaskData data = DigitSpanTaskData(
+      trials: db.trials,
+      device: db.device,
+      session: db.session,
     );
 
     return data;

--- a/lib/src/digit_span_task/components/data/data_manager.dart
+++ b/lib/src/digit_span_task/components/data/data_manager.dart
@@ -62,8 +62,8 @@ class DataManager extends GetxController {
   }
 
   /// Exports the data collected during the session.
-  /// Returns a custom object named [DigitSpanTasksData] that includes data for the
-  /// practice and experimental phase.
+  /// Includes data about the [trials] (practice and experimental)
+  /// and metadata about the [session] and [device] used to collect the data.
   DigitSpanTasksData export() {
     DigitSpanTasksData data = DigitSpanTasksData(
       practiceData: practiceData,

--- a/lib/src/digit_span_task/digit_span_tasks_activity.dart
+++ b/lib/src/digit_span_task/digit_span_tasks_activity.dart
@@ -1,4 +1,5 @@
 import 'package:digit_span_tasks/src/digit_span_task/components/config/session_type.dart';
+import 'package:digit_span_tasks/src/digit_span_task/components/data/digit_span_task_data.dart';
 import 'package:digit_span_tasks/src/digit_span_task/components/instructions/instructions_model.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -6,7 +7,6 @@ import 'package:digit_span_tasks/src/digit_span_task/components/config/ds_config
 import 'package:digit_span_tasks/src/digit_span_task/components/data/data_manager.dart';
 import 'package:digit_span_tasks/src/digit_span_task/components/activity/activity_controller.dart';
 import 'package:digit_span_tasks/src/digit_span_task/components/activity/activity_view.dart';
-import 'package:digit_span_tasks/src/digit_span_task/components/data/digit_span_tasks_data.dart';
 import 'package:digit_span_tasks/src/digit_span_task/components/ui_components/default_appbar.dart';
 import 'package:digit_span_tasks/src/digit_span_task/components/ui_components/screen.dart';
 import 'package:digit_span_tasks/src/digit_span_task/instructions_experimental.dart';
@@ -42,7 +42,7 @@ class DigitSpanTasksActivity extends StatelessWidget {
               await Get.to(() => InstructionsExperimental());
               await Get.to(() => ActivityView());
 
-              DigitSpanTasksData digitSpanTasksData = _data.export();
+              DigitSpanTaskData digitSpanTasksData = _data.export();
               Get.back(result: digitSpanTasksData);
             },
             child: Text(

--- a/test/src/digit_span_task/components/data/data_manager_test.dart
+++ b/test/src/digit_span_task/components/data/data_manager_test.dart
@@ -4,12 +4,16 @@ import 'package:digit_span_tasks/src/digit_span_task/components/config/session_t
 import 'package:digit_span_tasks/src/digit_span_task/components/data/data_manager.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
+import 'package:cognitive_data/cognitive_data.dart';
+import 'package:digit_span_tasks/src/digit_span_task/components/data/digit_span_task_data.dart';
 
 void main() {
   late DSConfig config;
   late DataManager manager;
 
   setUp(() {
+    Get.reset();
+
     /// insert config which contains [participantID] and [sessionID]
     Get.put(
       DSConfig(
@@ -27,22 +31,44 @@ void main() {
   });
 
   tearDown((() {
-    config.dispose();
+    Get.delete<DSConfig>();
   }));
 
+  test("DataManager.collectMetadata adds Session and Device data to db.", () {
+    manager.startTime = DateTime.now();
+
+    /// endTime can only be set during the experimental phase
+    config.sessionType = SessionType.experimental;
+    manager.endTime = DateTime.now();
+
+    manager.collectMetadata();
+
+    expect(manager.db.session.participantID, '101');
+    expect(manager.db.device.participantID, '101');
+  });
+
   test(
-    "DataManager.collectMetadata adds Session and Device data to db.",
+    "DataManager.export returns a DigitSpanTaskData with correct data",
     () {
       manager.startTime = DateTime.now();
 
       /// endTime can only be set during the experimental phase
       config.sessionType = SessionType.experimental;
       manager.endTime = DateTime.now();
+      final Trial trial = Trial(
+        participantID: participantID,
+        sessionID: '001',
+        trialType: TrialType.practice,
+        stim: '123',
+        response: '321',
+      );
+      manager.db.addTrial(trial: trial);
 
-      manager.collectMetadata();
+      final DigitSpanTaskData actual = manager.export();
 
-      expect(manager.db.session.participantID, '101');
-      expect(manager.db.device.participantID, '101');
+      expect(actual.trials.first.participantID, participantID);
+      expect(actual.device.participantID, participantID);
+      expect(actual.session.participantID, participantID);
     },
   );
 }

--- a/test/src/digit_span_task/components/data/data_manager_test.dart
+++ b/test/src/digit_span_task/components/data/data_manager_test.dart
@@ -10,6 +10,7 @@ import 'package:digit_span_tasks/src/digit_span_task/components/data/digit_span_
 void main() {
   late DSConfig config;
   late DataManager manager;
+  const String participantID = '101';
 
   setUp(() {
     Get.reset();
@@ -20,7 +21,7 @@ void main() {
         userConfig: UserConfig(
           stimListPractice: <String>[],
           stimListExperimental: <String>[],
-          participantID: '101',
+          participantID: participantID,
           sessionID: '001',
         ),
       ),


### PR DESCRIPTION
## Description

The structure of the data exported changed considerably. We now export a cleaner data object that only contains the trials, device metadata, and session metadata. 

The data for practice and experimental trials are integrated into a single object named trials and are identified by a flag (TrialType).

Metadata about the session and  device are collected considering the practice and experimental phases as part of a single session. This implies that the session start time is the time at which the practice started and the end time is the time at which the experimental session ended.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [project's code of conduct][code_conduct].
- [ ] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
