### PR TITLE
fix: Remove late from DigitSpanTaskData fields

### DIFF
--- a/lib/src/digit_span_task/components/data/digit_span_task_data.dart
+++ b/lib/src/digit_span_task/components/data/digit_span_task_data.dart
@@ -5,13 +5,13 @@ import 'package:cognitive_data/cognitive_data.dart';
 /// and metadata about the [session] and [device] used to collect the data.
 class DigitSpanTaskData {
   /// Data for all trials
-  late final List<Trial> trials;
+  final List<Trial> trials;
 
   /// Metadata about the session
-  late final Session session;
+  final Session session;
 
   /// Metadata about the device on which the data was collected
-  late final Device device;
+  final Device device;
 
   DigitSpanTaskData({
     required this.trials,


### PR DESCRIPTION
## Description

This potential bug was introduced during the merge of the `DigitSpanTasksData` and `DataModel` into a new object named `DigitSpanTasksData`.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🐞 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔧 Maintenance (non-breaking change that improves code)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix
- [ ] 🔐 Improvements to the CI workflow

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [project's code of conduct][code_conduct].
- [x] I've read the [contributing guide][CONTRIBUTING].
- [ ] I've written tests for all new methods and classes that I created.

[code_conduct]: ./CODE_OF_CONDUCT.md
[contributing]: ./CONTRIBUTING.md


<!-- Credits -->
<!-- This template is based on TezRomacH template
https://github.com/TezRomacH/python-package-template/blob/master/%7B%7B%20cookiecutter.project_name%20%7D%7D/.github/PULL_REQUEST_TEMPLATE.md -->
